### PR TITLE
Allow worker queue to be configurable 

### DIFF
--- a/lib/textris.rb
+++ b/lib/textris.rb
@@ -3,6 +3,8 @@ require 'action_mailer'
 require 'active_support'
 require 'phony'
 
+require 'textris/configuration'
+
 begin
   require 'twilio-ruby'
 rescue LoadError

--- a/lib/textris/configuration.rb
+++ b/lib/textris/configuration.rb
@@ -1,0 +1,6 @@
+module Textris
+  module Configuration
+    @@default_queue = 'textris'
+    mattr_accessor :default_queue
+  end
+end

--- a/lib/textris/delay/active_job.rb
+++ b/lib/textris/delay/active_job.rb
@@ -8,7 +8,12 @@ module Textris
       def deliver_later(options = {})
         job = Textris::Delay::ActiveJob::Job
 
-        job.new(texter(:raw => true).to_s, action.to_s, args).enqueue(options)
+        job.new(texter(:raw => true).to_s, action.to_s, args)
+          .enqueue(options.with_defaults(default_options))
+      end
+
+      def default_options
+        { queue: Configuration.default_queue }
       end
     end
   end

--- a/lib/textris/delay/sidekiq/proxy.rb
+++ b/lib/textris/delay/sidekiq/proxy.rb
@@ -13,12 +13,18 @@ module Textris
           args = [@texter, method_name, args]
 
           if @perform_in
-            ::Textris::Delay::Sidekiq::Worker.perform_in(@perform_in, *args)
+            worker.perform_in(@perform_in, *args)
           elsif @perform_at
-            ::Textris::Delay::Sidekiq::Worker.perform_at(@perform_at, *args)
+            worker.perform_at(@perform_at, *args)
           else
-            ::Textris::Delay::Sidekiq::Worker.perform_async(*args)
+            worker.perform_async(*args)
           end
+        end
+
+        private
+
+        def worker
+          ::Textris::Delay::Sidekiq::Worker.set(queue: Configuration.default_queue)
         end
       end
     end

--- a/lib/textris/delay/sidekiq/worker.rb
+++ b/lib/textris/delay/sidekiq/worker.rb
@@ -4,6 +4,8 @@ module Textris
       class Worker
         include ::Sidekiq::Worker
 
+        sidekiq_options queue: 'textris'
+
         def perform(texter, action, args)
           texter = texter.safe_constantize
 

--- a/spec/textris/delay/active_job_spec.rb
+++ b/spec/textris/delay/active_job_spec.rb
@@ -95,8 +95,11 @@ describe Textris::Delay::ActiveJob do
         job = MyTexter.delayed_action('48111222333').deliver_later
         expect(job.queue_name).to eq 'textris'
 
-        job = MyTexter.delayed_action('48111222333').deliver_later(:queue => :custom)
+        Textris::Configuration.default_queue = 'custom'
+        job = MyTexter.delayed_action('48111222333').deliver_later
         expect(job.queue_name).to eq 'custom'
+
+        Textris::Configuration.default_queue = 'textris'
       end
 
       it 'executes job properly' do

--- a/spec/textris/delay/sidekiq_spec.rb
+++ b/spec/textris/delay/sidekiq_spec.rb
@@ -184,6 +184,20 @@ describe Textris::Delay::Sidekiq do
     end
   end
 
+  context 'with a non-default queue set' do
+    describe 'enqueuing a job' do
+      it 'uses the custom queue' do
+        Textris::Configuration.default_queue = 'custom'
+        MyTexter.delay_for(1).delayed_action('48111222333', 'Hi')
+
+        queue = Textris::Delay::Sidekiq::Worker.jobs.last['queue']
+        expect(queue).to eq('custom')
+
+        Textris::Configuration.default_queue = 'textris'
+      end
+    end
+  end
+
   context 'sidekiq gem not present' do
     before do
       delegate = Class.new.extend(Textris::Delay::Sidekiq::Missing)


### PR DESCRIPTION
To support changes in korukids/web#3407, we need
to allow the worker queue to be configurable at runtime, ideally without
having to override the queue name in every worker call.

This change introduces a configuration module with the default queue
set, allowing the queue to be changed by setting:

`Textris::Configuration.default_queue = 'custom'`